### PR TITLE
Early Authentication + Eradication of api.Time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 *.swo
 *.DS_Store
+*.exe
+

--- a/api/api.go
+++ b/api/api.go
@@ -106,6 +106,20 @@ type Time struct {
 }
 
 /*
+Name: LongTime
+Type: API Input Struct
+Purpose: Provide a go indepent struct for representing time
+at a long scale(i.e. years + months + days)
+*/
+type LongTime struct {
+    Year            string
+    Month           string
+    Day             string
+    Hour            string
+    Minute          string
+}
+
+/*
 Name: ReserveParam
 Type: API Func Input Struct
 Purpose: Input information to the 'Reserve' api function 
@@ -140,6 +154,7 @@ type API interface {
     Login(params LoginParam) (*LoginResponse, error)
     Search(params SearchParam) (*SearchResponse, error)
     Reserve(params ReserveParam) (*ReserveResponse, error)
+    AuthMinExpire() (*LongTime)
 }
 
 /*

--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,7 @@ package api
 import (
     "errors"
     "strconv"
+    "time"
 )
 
 var (
@@ -98,12 +99,13 @@ type SearchResult struct {
 /*
 Name: Time
 Type: API Input Struct
-Purpose: Provide a go indepent struct for representing time
+Purpose: Provide a go independent struct for representing time
 */
+/*
 type Time struct {
-    Hour            string
-    Minute          string
+    CTime time.Time
 }
+*/
 
 /*
 Name: LongTime
@@ -111,13 +113,13 @@ Type: API Input Struct
 Purpose: Provide a go indepent struct for representing time
 at a long scale(i.e. years + months + days)
 */
-type LongTime struct {
+/*type LongTime struct {
     Year            string
     Month           string
     Day             string
     Hour            string
     Minute          string
-}
+}*/
 
 /*
 Name: ReserveParam
@@ -126,10 +128,7 @@ Purpose: Input information to the 'Reserve' api function
 */
 type ReserveParam struct {
     VenueID          int64
-    Day              string
-    Month            string
-    Year             string
-    ReservationTimes []Time
+    ReservationTimes []time.Time
     PartySize        int
     LoginResp        LoginResponse
 }
@@ -140,7 +139,7 @@ Type: API Func Output Struct
 Purpose: Output information from the 'Reserve' api function 
 */
 type ReserveResponse struct {
-    ReservationTime Time
+    ReservationTime time.Time
 }
 
 /*
@@ -154,7 +153,7 @@ type API interface {
     Login(params LoginParam) (*LoginResponse, error)
     Search(params SearchParam) (*SearchResponse, error)
     Reserve(params ReserveParam) (*ReserveResponse, error)
-    AuthMinExpire() (*LongTime)
+    AuthMinExpire() (time.Duration)
 }
 
 /*

--- a/api/doc.go
+++ b/api/doc.go
@@ -56,5 +56,15 @@ Search:
     reservation request.
     
 **********************************************************************   
+
+AuthMinExpire:
+
+    The AuthMinExpire function provides the minimum time irresepective
+    of time zone that a login token from the Login function is valid.
+    This function returns a constant value. If a null value is
+    returned, the login token is valid indefinitely.
+
+**********************************************************************   
+
 */
 package api

--- a/api/resy/api.go
+++ b/api/resy/api.go
@@ -245,7 +245,7 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
     
     // converting fields to url query format
     year := strconv.Itoa(params.ReservationTimes[0].Year())
-    month := params.ReservationTimes[0].Month().String()
+    month := strconv.Itoa(int(params.ReservationTimes[0].Month()))
     day := strconv.Itoa(params.ReservationTimes[0].Day())
     date := year + "-" + month + "-" + day
     dayField := `day=` + date
@@ -293,6 +293,7 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
         return nil, err
     }
 
+
     // JSON structure is complicated here, see api/resy/doc.go for full explanation
     jsonResultsMap := jsonTopLevelMap["results"].(map[string]interface{}) 
     jsonVenuesList := jsonResultsMap["venues"].([]interface{})
@@ -301,7 +302,7 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
     }
     jsonVenueMap := jsonVenuesList[0].(map[string]interface{})
     jsonSlotsList := jsonVenueMap["slots"].([]interface{}) 
-    for i:=0; i < len(params.ReservationTimes); i++ {
+    for i := 0; i < len(params.ReservationTimes); i++ {
 
         currentTime := params.ReservationTimes[i]
         for j:=0; j < len(jsonSlotsList); j++ {

--- a/api/resy/api.go
+++ b/api/resy/api.go
@@ -405,6 +405,23 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
     return nil, api.ErrNoTable 
 }
 
+/*
+Name: AuthMinExpire 
+Type: API Func 
+Purpose: Resy implementation of the AuthMinExpire api func.
+The largest minimum validity time is 6 days.
+*/
+func (a *API) AuthMinExpire() (*api.LongTime) {
+    /* 6 days */
+    return &api.LongTime {
+        Year: "00",
+        Month: "00",
+        Day: "06",
+        Hour: "00",
+        Minute: "00",
+    }
+}
+
 //func (a *API) Cancel(params api.CancelParam) (*api.CancelResponse, error) {
 //    cancelUrl := `https://api.resy.com/3/cancel` 
 //    resyToken := url.QueryEscape(params.ResyToken)

--- a/app/app.go
+++ b/app/app.go
@@ -391,8 +391,6 @@ a reservation at a given time
 */
 func (a *AppCtx) reserveAtTime(params ReserveAtTimeParam, cancel <-chan bool, output chan<- OperationResult) {
  
-    minAuthTime := a.API.AuthMinExpire()
-
     // if this date is not in the future, err 
     if params.RequestTime.Before(time.Now().UTC()) {
         output <- OperationResult{Response: nil, Err: ErrTimeFut}     
@@ -400,6 +398,7 @@ func (a *AppCtx) reserveAtTime(params ReserveAtTimeParam, cancel <-chan bool, ou
         return
     }
 
+    minAuthTime := a.API.AuthMinExpire()
     authDate := params.RequestTime.Add(-1 * minAuthTime)
     if (!authDate.Before(time.Now().UTC())) {
         select {
@@ -413,13 +412,13 @@ func (a *AppCtx) reserveAtTime(params ReserveAtTimeParam, cancel <-chan bool, ou
     }
 
     loginResp, err := a.API.Login(api.LoginParam(params.Login))
+
     if err != nil {
        output<- OperationResult{Response: nil, Err:err}
        close(output)
        return
     }
  
-
     // sleep with ability to cancel 
     select {
     case <-time.After(time.Until(params.RequestTime)):
@@ -428,7 +427,6 @@ func (a *AppCtx) reserveAtTime(params ReserveAtTimeParam, cancel <-chan bool, ou
         close(output)
         return
     }
-
 
     // reserve 
     reserveResp, err := a.API.Reserve(

--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
     "errors"
     "time"
     "strconv"
+    "fmt"
 )
 
 var (
@@ -551,7 +552,7 @@ func (a *AppCtx) OperationsToString() (string, error) {
             case SuccessStatusType:
                 time := operation.Result.Response.Time()
                 opLstStr += "Succeeded\n"
-                opLstStr += "\tResult: " + strconv.Itoa(time.Hour()) + ":" + strconv.Itoa(time.Minute())
+                opLstStr += fmt.Sprintf("\tResult: %02d:%02d", time.Hour(), time.Minute())
             case FailStatusType:
                 err := operation.Result.Err.Error()
                 opLstStr += "Failed\n"

--- a/runnable/cli/runnable.go
+++ b/runnable/cli/runnable.go
@@ -173,17 +173,36 @@ func (c *ResolvedCLI) parseRats(in map[string][]string) (*app.ReserveAtTimeParam
     if len(resDaySplt) != 3 {
         return nil, ErrInvDate
     }
-    req.Year = resDaySplt[0] 
-    req.Month = resDaySplt[1]
-    req.Day = resDaySplt[2]
-    req.ReservationTimes = make([]api.Time, len(in["resT"]), len(in["resT"]))
+
+    reqYear, err := strconv.Atoi(resDaySplt[0])
+    if err != nil {
+        return nil, err
+    }
+    reqMonth, err := strconv.Atoi(resDaySplt[1])
+    if err != nil {
+        return nil, err
+    }
+    reqDay, err := strconv.Atoi(resDaySplt[2])
+    if err != nil {
+        return nil, err
+    }
+
+    req.ReservationTimes = make([]time.Time, len(in["resT"]), len(in["resT"]))
     for i, timeStr := range in["resT"] {
         timeSplt := strings.Split(timeStr, ":")        
         if len(timeSplt) != 2 {
             return nil, ErrInvDate
         }
-        req.ReservationTimes[i].Hour = timeSplt[0]
-        req.ReservationTimes[i].Minute = timeSplt[1]
+        reqHour, err := strconv.Atoi(timeSplt[0])
+        if err != nil {
+            return nil, err
+        }
+        reqMin, err := strconv.Atoi(timeSplt[1])
+        if err != nil {
+            return nil, err
+        }
+        req.ReservationTimes[i] = time.Date(reqYear, time.Month(reqMonth), reqDay, reqHour, reqMin, 0, 0, time.Local)
+
     }
     ps, err := strconv.ParseInt(in["ps"][0], 10, 64)
     if err != nil {
@@ -219,12 +238,7 @@ func (c *ResolvedCLI) parseRats(in map[string][]string) (*app.ReserveAtTimeParam
     }
     timeLoc := time.Date(int(year), time.Month(int(month)), int(day), int(hour), int(minute), 0, 0, time.Local)
     timeUTC := timeLoc.UTC()
-    yearu, monthu, dayu := timeUTC.Date()
-    req.RequestYear = strconv.Itoa(yearu)
-    req.RequestMonth = strconv.Itoa(int(monthu))
-    req.RequestDay = strconv.Itoa(dayu)
-    req.RequestTime.Hour = strconv.Itoa(timeUTC.Hour())
-    req.RequestTime.Minute =  strconv.Itoa(timeUTC.Minute())
+    req.RequestTime = timeUTC
     return &req, nil
 }
 
@@ -278,17 +292,33 @@ func (c *ResolvedCLI) parseRais(in map[string][]string) (*app.ReserveAtIntervalP
     if len(resDaySplt) != 3 {
         return nil, ErrInvDate
     }
-    req.Year = resDaySplt[0] 
-    req.Month = resDaySplt[1]
-    req.Day = resDaySplt[2]
-    req.ReservationTimes = make([]api.Time, len(in["resT"]), len(in["resT"]))
+    reqYear, err := strconv.Atoi(resDaySplt[0])
+    if err != nil {
+        return nil, err
+    }
+    reqMonth, err := strconv.Atoi(resDaySplt[1])
+    if err != nil {
+        return nil, err
+    }
+    reqDay, err := strconv.Atoi(resDaySplt[2])
+    if err != nil {
+        return nil, err
+    }
+    req.ReservationTimes = make([]time.Time, len(in["resT"]), len(in["resT"]))
     for i, timeStr := range in["resT"] {
         timeSplt := strings.Split(timeStr, ":")        
         if len(timeSplt) != 2 {
             return nil, ErrInvDate
         }
-        req.ReservationTimes[i].Hour = timeSplt[0]
-        req.ReservationTimes[i].Minute = timeSplt[1]
+        reqHour, err := strconv.Atoi(timeSplt[0])
+        if err != nil {
+            return nil, err
+        }
+        reqMin, err := strconv.Atoi(timeSplt[1])
+        if err != nil {
+            return nil, err
+        }
+        req.ReservationTimes[i] = time.Date(reqYear, time.Month(reqMonth), reqDay, reqHour, reqMin, 0, 0, time.Local)
     }
     ps, err := strconv.ParseInt(in["ps"][0], 10, 64)
     if err != nil {
@@ -301,9 +331,17 @@ func (c *ResolvedCLI) parseRais(in map[string][]string) (*app.ReserveAtIntervalP
     if len(repIntSplt) != 2 {
         return nil, ErrInvDate
     }
-    req.RepeatInterval.Hour = repIntSplt[0]
-    req.RepeatInterval.Minute = repIntSplt[1]
- 
+
+    repHour, err := strconv.Atoi(repIntSplt[0])
+    if err != nil {
+        return nil, err
+    }
+    repMin, err := strconv.Atoi(repIntSplt[1])
+    if err != nil {
+        return nil, err
+    }
+    req.RepeatInterval = time.Hour * time.Duration(repHour) + time.Minute * time.Duration(repMin)
+
     return &req, nil
 }
 


### PR DESCRIPTION
This branch contains the logic to allow for early authentication and therefore to reduce the RTT of a reservation transaction by approximately 1/4. This branch also contains a rewrite of all time dependent code to use the standard go time package rather than the old api.Time object, and thus a significant reduction in the complexity of the code of the bot.