### PR TITLE
option to specify table type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.swo
 *.DS_Store
 *.exe
-
+*~

--- a/api/api.go
+++ b/api/api.go
@@ -97,30 +97,15 @@ type SearchResult struct {
     Neighborhood    string
 }
 
-/*
-Name: LongTime
-Type: API Input Struct
-Purpose: Provide a go indepent struct for representing time
-at a long scale(i.e. years + months + days)
-*/
-/*type LongTime struct {
-    Year            string
-    Month           string
-    Day             string
-    Hour            string
-    Minute          string
-}*/
-
-type TableType int64
+type TableType string
 
 const (
-    Empty TableType = iota
-    DiningRoom
-    Indoor
-    Outdoor
-    Patio
-    Bar
-    Lounge
+    DiningRoom TableType = "dining"
+    Indoor               = "indoor"
+    Outdoor              = "outdoor"
+    Patio                = "patio"
+    Bar                  = "bar"
+    Lounge               = "lounge"
 )
 
 /*
@@ -132,7 +117,7 @@ type ReserveParam struct {
     VenueID          int64
     ReservationTimes []time.Time
     PartySize        int
-    Table            TableType
+    TableTypes       []TableType
     LoginResp        LoginResponse
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -97,6 +97,11 @@ type SearchResult struct {
     Neighborhood    string
 }
 
+/*
+Name: TableType 
+Type: API Input Struct
+Purpose: Allow an opaque interface for choosing table/seating type
+*/
 type TableType string
 
 const (
@@ -106,6 +111,7 @@ const (
     Patio                = "patio"
     Bar                  = "bar"
     Lounge               = "lounge"
+    Booth                = "booth"
 )
 
 /*

--- a/api/api.go
+++ b/api/api.go
@@ -20,6 +20,7 @@ var (
     ErrNoPayInfo = errors.New("no payment info on account")
 )
 
+
 /*
 Name: LoginParam
 Type: API Func Input Struct
@@ -97,17 +98,6 @@ type SearchResult struct {
 }
 
 /*
-Name: Time
-Type: API Input Struct
-Purpose: Provide a go independent struct for representing time
-*/
-/*
-type Time struct {
-    CTime time.Time
-}
-*/
-
-/*
 Name: LongTime
 Type: API Input Struct
 Purpose: Provide a go indepent struct for representing time
@@ -121,6 +111,18 @@ at a long scale(i.e. years + months + days)
     Minute          string
 }*/
 
+type TableType int64
+
+const (
+    Empty TableType = iota
+    DiningRoom
+    Indoor
+    Outdoor
+    Patio
+    Bar
+    Lounge
+)
+
 /*
 Name: ReserveParam
 Type: API Func Input Struct
@@ -130,6 +132,7 @@ type ReserveParam struct {
     VenueID          int64
     ReservationTimes []time.Time
     PartySize        int
+    Table            TableType
     LoginResp        LoginResponse
 }
 

--- a/api/resy/api.go
+++ b/api/resy/api.go
@@ -305,10 +305,10 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
     for k := 0; k < len(params.TableTypes) || (len(params.TableTypes) == 0 && k == 0) ; k++ {
         // table type to search for, we decide this early on since its the least important thing
         
-//        currentTableType := "" 
-//        if len(params.TableTypes) != 0 {
-//            currentTableType = params.TableTypes[k]
-//        }
+        currentTableType := api.DiningRoom
+        if len(params.TableTypes) != 0 {
+            currentTableType = params.TableTypes[k]
+        }
         
         for i := 0; i < len(params.ReservationTimes); i++ {
 
@@ -338,8 +338,9 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
                 }
 
                 jsonConfigMap := jsonSlotMap["config"].(map[string]interface{})
-               // tableType := strings.ToLower(jsonConfigMap["type"].(string))
-                if hourFieldInt == currentTime.Hour() && minFieldInt == currentTime.Minute() {
+                // get table type of this slot for comparison
+                tableType := strings.ToLower(jsonConfigMap["type"].(string))
+                if hourFieldInt == currentTime.Hour() && minFieldInt == currentTime.Minute() && (len(params.TableTypes) == 0 || strings.Contains(tableType, string(currentTableType))){
                     configToken := jsonConfigMap["token"].(string)
                     configIDField := `config_id=` + url.QueryEscape(configToken)
                     // Reuse same fields from def of findUrl(see api/resy/doc.go)

--- a/api/resy/api.go
+++ b/api/resy/api.go
@@ -302,119 +302,128 @@ func (a *API) Reserve(params api.ReserveParam) (*api.ReserveResponse, error) {
     }
     jsonVenueMap := jsonVenuesList[0].(map[string]interface{})
     jsonSlotsList := jsonVenueMap["slots"].([]interface{}) 
-    for i := 0; i < len(params.ReservationTimes); i++ {
+    for k := 0; k < len(params.TableTypes) || (len(params.TableTypes) == 0 && k == 0) ; k++ {
+        // table type to search for, we decide this early on since its the least important thing
+        
+//        currentTableType := "" 
+//        if len(params.TableTypes) != 0 {
+//            currentTableType = params.TableTypes[k]
+//        }
+        
+        for i := 0; i < len(params.ReservationTimes); i++ {
 
-        currentTime := params.ReservationTimes[i]
-        for j:=0; j < len(jsonSlotsList); j++ {
-            // if any errs appear, we just move to next time on list(i.e. continue)
+            currentTime := params.ReservationTimes[i]
+            for j:=0; j < len(jsonSlotsList); j++ {
+                // if any errs appear, we just move to next time on list(i.e. continue)
 
-            jsonSlotMap := jsonSlotsList[j].(map[string]interface{})
-            jsonDateMap:= jsonSlotMap["date"].(map[string]interface{})
+                jsonSlotMap := jsonSlotsList[j].(map[string]interface{})
+                jsonDateMap:= jsonSlotMap["date"].(map[string]interface{})
 
-            // start contains the date for this slot in format "YrYrYrYr-MoMo-DyDy HrHr:MnMn"
-            startRaw := jsonDateMap["start"].(string)
-            // split to get ["YrYrYrYr-MoMo-DyDy", "HrHr:MnMn"]
-            startFields := strings.Split(startRaw, " ")
-            // isolate time field and split to get ["HrHr","MnMn"]
-            timeFields := strings.Split(startFields[1], ":")
-            // if time field matches of slot matches current selected ResTime, move to config step
+                // start contains the date for this slot in format "YrYrYrYr-MoMo-DyDy HrHr:MnMn"
+                startRaw := jsonDateMap["start"].(string)
+                // split to get ["YrYrYrYr-MoMo-DyDy", "HrHr:MnMn"]
+                startFields := strings.Split(startRaw, " ")
+                // isolate time field and split to get ["HrHr","MnMn"]
+                timeFields := strings.Split(startFields[1], ":")
+                // if time field matches of slot matches current selected ResTime, move to config step
 
-            hourFieldInt, err := strconv.Atoi(timeFields[0])
-            if err != nil {
-                return nil, err
-            }
-
-            minFieldInt, err := strconv.Atoi(timeFields[1])
-            if err != nil {
-                return nil, err
-            }
-
-            if hourFieldInt == currentTime.Hour() && minFieldInt == currentTime.Minute() {
-                jsonConfigMap := jsonSlotMap["config"].(map[string]interface{})
-                configToken := jsonConfigMap["token"].(string)
-                configIDField := `config_id=` + url.QueryEscape(configToken)
-                // Reuse same fields from def of findUrl(see api/resy/doc.go)
-                fields = []string{dayField, partySizeField, authField, venueIDField, configIDField}
-
-                detailUrl := "https://api.resy.com/3/details?" + strings.Join(fields, "&") 
-
-                requestDetail, err := http.NewRequest("GET", detailUrl, bytes.NewBuffer([]byte{}))
-                if err != nil {
-                    continue 
-                }
-
-                requestDetail.Header.Set("Authorization", `ResyAPI api_key="` + a.APIKey + `"`)
-                requestDetail.Header.Set("Host", `api.resy.com`)
-                requestDetail.Header.Set("X-Resy-Auth-Token", params.LoginResp.AuthToken)
-                requestDetail.Header.Set("X-Resy-Universal-Auth-Token", params.LoginResp.AuthToken)
-            
-                responseDetail, err := client.Do(requestDetail)
-                if err != nil {
-                    continue
-                }
-
-                if isCodeFail(responseDetail.StatusCode) {
-                    return nil, api.ErrNetwork
-                }
-
-                defer responseDetail.Body.Close()
-
-                responseDetailBody, err := io.ReadAll(responseDetail.Body)
-                if err != nil {
-                    continue
-                }
-
-                var jsonTopLevelMap map[string]interface{}
-                err = json.Unmarshal(responseDetailBody, &jsonTopLevelMap)
+                hourFieldInt, err := strconv.Atoi(timeFields[0])
                 if err != nil {
                     return nil, err
                 }
-                jsonBookTokenMap := jsonTopLevelMap["book_token"].(map[string]interface{}) 
-                bookToken := jsonBookTokenMap["value"].(string)
+
+                minFieldInt, err := strconv.Atoi(timeFields[1])
+                if err != nil {
+                    return nil, err
+                }
+
+                jsonConfigMap := jsonSlotMap["config"].(map[string]interface{})
+               // tableType := strings.ToLower(jsonConfigMap["type"].(string))
+                if hourFieldInt == currentTime.Hour() && minFieldInt == currentTime.Minute() {
+                    configToken := jsonConfigMap["token"].(string)
+                    configIDField := `config_id=` + url.QueryEscape(configToken)
+                    // Reuse same fields from def of findUrl(see api/resy/doc.go)
+                    fields = []string{dayField, partySizeField, authField, venueIDField, configIDField}
+
+                    detailUrl := "https://api.resy.com/3/details?" + strings.Join(fields, "&") 
+
+                    requestDetail, err := http.NewRequest("GET", detailUrl, bytes.NewBuffer([]byte{}))
+                    if err != nil {
+                        continue 
+                    }
+
+                    requestDetail.Header.Set("Authorization", `ResyAPI api_key="` + a.APIKey + `"`)
+                    requestDetail.Header.Set("Host", `api.resy.com`)
+                    requestDetail.Header.Set("X-Resy-Auth-Token", params.LoginResp.AuthToken)
+                    requestDetail.Header.Set("X-Resy-Universal-Auth-Token", params.LoginResp.AuthToken)
+                
+                    responseDetail, err := client.Do(requestDetail)
+                    if err != nil {
+                        continue
+                    }
+
+                    if isCodeFail(responseDetail.StatusCode) {
+                        return nil, api.ErrNetwork
+                    }
+
+                    defer responseDetail.Body.Close()
+
+                    responseDetailBody, err := io.ReadAll(responseDetail.Body)
+                    if err != nil {
+                        continue
+                    }
+
+                    var jsonTopLevelMap map[string]interface{}
+                    err = json.Unmarshal(responseDetailBody, &jsonTopLevelMap)
+                    if err != nil {
+                        return nil, err
+                    }
+                    jsonBookTokenMap := jsonTopLevelMap["book_token"].(map[string]interface{}) 
+                    bookToken := jsonBookTokenMap["value"].(string)
  
-                // if config step yielded a book token, move to 'reserve' step
-                bookUrl := "https://api.resy.com/3/book?" + strings.Join(fields, "&") 
+                    // if config step yielded a book token, move to 'reserve' step
+                    bookUrl := "https://api.resy.com/3/book?" + strings.Join(fields, "&") 
 
-                bookField := "book_token=" + url.QueryEscape(bookToken)
-                paymentMethodStr := `{"id":` + strconv.FormatInt(params.LoginResp.PaymentMethodID, 10) + `}`
-                paymentMethodField := "struct_payment_method=" + url.QueryEscape(paymentMethodStr)
-                requestBookBodyStr := bookField + "&" + paymentMethodField + "&" + "source_id=resy.com-venue-details"
-                requestBook, err := http.NewRequest("POST", bookUrl, bytes.NewBuffer([]byte(requestBookBodyStr)))
-                requestBook.Header.Set("Authorization", `ResyAPI api_key="` + a.APIKey + `"`)
-                requestBook.Header.Set("Content-Type", `application/x-www-form-urlencoded`)
-                requestBook.Header.Set("Host", `api.resy.com`)
-                requestBook.Header.Set("X-Resy-Auth-Token", params.LoginResp.AuthToken)
-                requestBook.Header.Set("X-Resy-Universal-Auth-Token", params.LoginResp.AuthToken)
-                requestBook.Header.Set("Referer", "https://resy.com/")
-                responseBook, err := client.Do(requestBook)
-                if err != nil {
-                   continue 
+                    bookField := "book_token=" + url.QueryEscape(bookToken)
+                    paymentMethodStr := `{"id":` + strconv.FormatInt(params.LoginResp.PaymentMethodID, 10) + `}`
+                    paymentMethodField := "struct_payment_method=" + url.QueryEscape(paymentMethodStr)
+                    requestBookBodyStr := bookField + "&" + paymentMethodField + "&" + "source_id=resy.com-venue-details"
+                    requestBook, err := http.NewRequest("POST", bookUrl, bytes.NewBuffer([]byte(requestBookBodyStr)))
+                    requestBook.Header.Set("Authorization", `ResyAPI api_key="` + a.APIKey + `"`)
+                    requestBook.Header.Set("Content-Type", `application/x-www-form-urlencoded`)
+                    requestBook.Header.Set("Host", `api.resy.com`)
+                    requestBook.Header.Set("X-Resy-Auth-Token", params.LoginResp.AuthToken)
+                    requestBook.Header.Set("X-Resy-Universal-Auth-Token", params.LoginResp.AuthToken)
+                    requestBook.Header.Set("Referer", "https://resy.com/")
+                    responseBook, err := client.Do(requestBook)
+                    if err != nil {
+                       continue 
+                    }
+
+                    if isCodeFail(responseBook.StatusCode) {
+                        continue
+                    }
+
+                    responseBookBody, err := io.ReadAll(responseBook.Body)
+                    if err != nil {
+                        continue
+                    }
+
+                    err = json.Unmarshal(responseBookBody, &jsonTopLevelMap)
+                    if err != nil {
+                        continue
+                    }
+
+                    // if everything worked out, return time
+                    resp := api.ReserveResponse{
+                        ReservationTime: currentTime,
+                    }
+
+                    return &resp, nil
+
                 }
-
-                if isCodeFail(responseBook.StatusCode) {
-                    continue
-                }
-
-                responseBookBody, err := io.ReadAll(responseBook.Body)
-                if err != nil {
-                    continue
-                }
-
-                err = json.Unmarshal(responseBookBody, &jsonTopLevelMap)
-                if err != nil {
-                    continue
-                }
-
-                // if everything worked out, return time
-                resp := api.ReserveResponse{
-                    ReservationTime: currentTime,
-                }
-
-                return &resp, nil
-
             }
         }
-         
     }
    
     // we only reach here if every time failed, meaning no table

--- a/api/resy/doc.go
+++ b/api/resy/doc.go
@@ -233,6 +233,7 @@ Reserve:
                                                 "config": 
                                                     {
                                                         ...
+                                                        "type": "###TABLETYPE###",
                                                         "token": "###CONFTOKEN###",
                                                         ...
                                                     },
@@ -252,7 +253,8 @@ Reserve:
     Where ###YR###, ###MT###, ###DY###, ###HR###, and ###MN###, are
     the year, month, day, hour, and minute respectfully of an open slot in
     military time format, and the ###CONFTOKEN### is an identifier for the
-    slot used in the next request-response interaction.
+    slot used in the next request-response interaction. The string token ###TABLETYPE###
+    is the type of table that this slot corresponds to.
 
     The next pair of HTTP messages is informally referred to as the 'config' 
     step. We send a GET request with no body. The request has a dynamic URL:

--- a/app/app.go
+++ b/app/app.go
@@ -40,7 +40,6 @@ type SearchParam api.SearchParam
 
 type SearchResponse api.SearchResponse
 
-type TableType api.TableType
 /*
 Name: AppCtx
 Type: External App Struct
@@ -76,7 +75,7 @@ type ReserveAtIntervalParam struct {
     ReservationTimes []time.Time
     PartySize        int
     RepeatInterval   time.Duration
-    TableType 	     TableType
+    TableTypes 	     []api.TableType
 }
 
 /*
@@ -91,7 +90,7 @@ type ReserveAtTimeParam struct {
     ReservationTimes []time.Time
     PartySize        int
     RequestTime      time.Time
-    TableType        TableType
+    TableTypes 	     []api.TableType
 }
 
 /*
@@ -295,6 +294,7 @@ Purpose: This function is intended to run on a separate thread, and tries making
 a reservation at a given interval of time
 */
 func (a *AppCtx) reserveAtInterval(params ReserveAtIntervalParam, cancel <-chan bool, output chan<- OperationResult){
+
     // find and store last time from time priority list
     lastTime, err := findLastTime(params.ReservationTimes)
 
@@ -322,6 +322,7 @@ func (a *AppCtx) reserveAtInterval(params ReserveAtIntervalParam, cancel <-chan 
                 ReservationTimes: params.ReservationTimes,
                 PartySize: params.PartySize,
                 VenueID: params.VenueID,
+                TableTypes: params.TableTypes,
             })
 
         // if there was an error and it wasn't due to every time being
@@ -439,6 +440,7 @@ func (a *AppCtx) reserveAtTime(params ReserveAtTimeParam, cancel <-chan bool, ou
             ReservationTimes: params.ReservationTimes,
             PartySize: params.PartySize,
             VenueID: params.VenueID,
+            TableTypes: []api.TableType(params.TableTypes),
         })
 
     if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -40,6 +40,7 @@ type SearchParam api.SearchParam
 
 type SearchResponse api.SearchResponse
 
+type TableType api.TableType
 /*
 Name: AppCtx
 Type: External App Struct
@@ -75,6 +76,7 @@ type ReserveAtIntervalParam struct {
     ReservationTimes []time.Time
     PartySize        int
     RepeatInterval   time.Duration
+    TableType 	     TableType
 }
 
 /*
@@ -89,6 +91,7 @@ type ReserveAtTimeParam struct {
     ReservationTimes []time.Time
     PartySize        int
     RequestTime      time.Time
+    TableType        TableType
 }
 
 /*

--- a/runnable/cli/runnable.go
+++ b/runnable/cli/runnable.go
@@ -163,6 +163,33 @@ func (c *ResolvedCLI) parseRats(in map[string][]string) (*app.ReserveAtTimeParam
     if in["p"] != nil {
         req.Login.Password = in["p"][0]
     }
+    if in["t"] != nil {
+	req.TableTypes = make ([]TableTypes, len(in["t"]), len(in["t"])) 
+	for i := 0; i < len(in["t"]); i++ {
+            currType = in["t"][i]
+	    if strings.Contains(currType, api.DiningRoom) {
+                req.TableTypes[i] = api.DiningRoom
+	    }
+	    else if strings.Contains(currType, api.Indoor) {
+                req.TableTypes[i] = api.Indoor
+	    }
+	    else if strings.Contains(currType, api.Outdoor) {
+                req.TableTypes[i] = api.Outdoor
+	    }
+	    else if strings.Contains(currType, api.Patio) {
+                req.TableTypes[i] = api.Patio
+	    }
+	    else if strings.Contains(currType, api.Bar) {
+                req.TableTypes[i] = api.Bar
+	    }
+	    else if strings.Contains(currType, api.Lounge) {
+                req.TableTypes[i] = api.Lounge
+	    } 
+	    else if strings.Contains(currType, api.Booth) {
+                req.TableTypes[i] = api.Booth
+	    }
+	}	
+    }    
     id, err := strconv.ParseInt(in["v"][0], 10, 64)
     if err != nil {
         return nil, err
@@ -283,8 +310,32 @@ func (c *ResolvedCLI) parseRais(in map[string][]string) (*app.ReserveAtIntervalP
         req.Login.Password = in["p"][0]
     } 
     if in["t"] != nil {
-	
-    }
+	req.TableTypes = make ([]TableTypes, len(in["t"]), len(in["t"])) 
+	for i := 0; i < len(in["t"]); i++ {
+            currType = in["t"][i]
+	    if strings.Contains(currType, api.DiningRoom) {
+                req.TableTypes[i] = api.DiningRoom
+	    }
+	    else if strings.Contains(currType, api.Indoor) {
+                req.TableTypes[i] = api.Indoor
+	    }
+	    else if strings.Contains(currType, api.Outdoor) {
+                req.TableTypes[i] = api.Outdoor
+	    }
+	    else if strings.Contains(currType, api.Patio) {
+                req.TableTypes[i] = api.Patio
+	    }
+	    else if strings.Contains(currType, api.Bar) {
+                req.TableTypes[i] = api.Bar
+	    }
+	    else if strings.Contains(currType, api.Lounge) {
+                req.TableTypes[i] = api.Lounge
+	    } 
+	    else if strings.Contains(currType, api.Booth) {
+                req.TableTypes[i] = api.Booth
+	    }
+	}	
+    } 
     id, err := strconv.ParseInt(in["v"][0], 10, 64)
     if err != nil {
         return nil, err
@@ -718,26 +769,6 @@ func (c *ResolvedCLI) initParseCtx() {
                 Name: "p",
                 LongName: "password",
                 Description: "This flag is required. Provides login password",
-                ValidationCtx: cli.FlagValidationCtx{
-                    Required: true,
-                    MaxArgs: 1,
-                    MinArgs: 1,
-                },
-            },
-        },
-        Handler: c.handleLogin,
-    }
-
-    // 'logout' command
-    logoutCommand := cli.Command{
-        Name: "logout",
-        Description: "Clear default login credentials",
-        Flags: []cli.Flag{},
-        Handler: c.handleLogout,
-    }
-
-    // 'cancel' command
-    cancelCommand := cli.Command{
         Name: "cancel",
         Description: "Cancel operations given ids",
         Flags: []cli.Flag{

--- a/runnable/cli/runnable.go
+++ b/runnable/cli/runnable.go
@@ -21,6 +21,8 @@ import (
 var (
     // Error if we can't parse date properly
     ErrInvDate = errors.New("invalid date format")
+    // Error if we can't parse table type properly
+    ErrInvTableType = errors.New("invalid table type")
 )
 
 /*
@@ -164,32 +166,28 @@ func (c *ResolvedCLI) parseRats(in map[string][]string) (*app.ReserveAtTimeParam
         req.Login.Password = in["p"][0]
     }
     if in["t"] != nil {
-	req.TableTypes = make ([]TableTypes, len(in["t"]), len(in["t"])) 
-	for i := 0; i < len(in["t"]); i++ {
-            currType = in["t"][i]
-	    if strings.Contains(currType, api.DiningRoom) {
+	    req.TableTypes = make([]api.TableType, len(in["t"]), len(in["t"])) 
+	    for i := 0; i < len(in["t"]); i++ {
+            currType := strings.ToLower(in["t"][i])
+	        if strings.Contains(currType, string(api.DiningRoom)) {
                 req.TableTypes[i] = api.DiningRoom
-	    }
-	    else if strings.Contains(currType, api.Indoor) {
+	        } else if strings.Contains(currType, string(api.Indoor)) {
                 req.TableTypes[i] = api.Indoor
-	    }
-	    else if strings.Contains(currType, api.Outdoor) {
+	        } else if strings.Contains(currType, string(api.Outdoor)) {
                 req.TableTypes[i] = api.Outdoor
-	    }
-	    else if strings.Contains(currType, api.Patio) {
+	        } else if strings.Contains(currType, string(api.Patio)) {
                 req.TableTypes[i] = api.Patio
-	    }
-	    else if strings.Contains(currType, api.Bar) {
+	        } else if strings.Contains(currType, string(api.Bar)) {
                 req.TableTypes[i] = api.Bar
-	    }
-	    else if strings.Contains(currType, api.Lounge) {
+	        } else if strings.Contains(currType, string(api.Lounge)) {
                 req.TableTypes[i] = api.Lounge
-	    } 
-	    else if strings.Contains(currType, api.Booth) {
+	        } else if strings.Contains(currType, string(api.Booth)) {
                 req.TableTypes[i] = api.Booth
-	    }
-	}	
-    }    
+	        } else {
+                return nil, ErrInvTableType
+            }
+	    }	
+    }
     id, err := strconv.ParseInt(in["v"][0], 10, 64)
     if err != nil {
         return nil, err
@@ -310,32 +308,28 @@ func (c *ResolvedCLI) parseRais(in map[string][]string) (*app.ReserveAtIntervalP
         req.Login.Password = in["p"][0]
     } 
     if in["t"] != nil {
-	req.TableTypes = make ([]TableTypes, len(in["t"]), len(in["t"])) 
-	for i := 0; i < len(in["t"]); i++ {
-            currType = in["t"][i]
-	    if strings.Contains(currType, api.DiningRoom) {
+	    req.TableTypes = make([]api.TableType, len(in["t"]), len(in["t"])) 
+	    for i := 0; i < len(in["t"]); i++ {
+            currType := in["t"][i]
+	        if strings.Contains(currType, string(api.DiningRoom)) {
                 req.TableTypes[i] = api.DiningRoom
-	    }
-	    else if strings.Contains(currType, api.Indoor) {
+	        } else if strings.Contains(currType, string(api.Indoor)) {
                 req.TableTypes[i] = api.Indoor
-	    }
-	    else if strings.Contains(currType, api.Outdoor) {
+	        } else if strings.Contains(currType, string(api.Outdoor)) {
                 req.TableTypes[i] = api.Outdoor
-	    }
-	    else if strings.Contains(currType, api.Patio) {
+	        } else if strings.Contains(currType, string(api.Patio)) {
                 req.TableTypes[i] = api.Patio
-	    }
-	    else if strings.Contains(currType, api.Bar) {
+	        } else if strings.Contains(currType, string(api.Bar)) {
                 req.TableTypes[i] = api.Bar
-	    }
-	    else if strings.Contains(currType, api.Lounge) {
+	        } else if strings.Contains(currType, string(api.Lounge)) {
                 req.TableTypes[i] = api.Lounge
-	    } 
-	    else if strings.Contains(currType, api.Booth) {
+	        } else if strings.Contains(currType, string(api.Booth)) {
                 req.TableTypes[i] = api.Booth
-	    }
-	}	
-    } 
+	        } else {
+                return nil, ErrInvTableType
+            }
+	    }	
+    }    
     id, err := strconv.ParseInt(in["v"][0], 10, 64)
     if err != nil {
         return nil, err
@@ -596,16 +590,16 @@ func (c *ResolvedCLI) initParseCtx() {
                     MaxArgs: 1,
                 },
             },
-	    cli.Flag{
-		Name: "t",
-		LongName: "table",
-		Description: "This flag is optional. Used to set the type of table in order of preference",
-		ValidationCtx: cli.FlagValidationCtx{
-		    Required: false,
-		    MinArgs: 1,
-		    MaxArgs: cli.InfiniteArgs, 
-		},
-	    },
+	        cli.Flag{
+		        Name: "t",
+		        LongName: "table",
+		        Description: "This flag is optional. Used to set the type of table in order of preference",
+		        ValidationCtx: cli.FlagValidationCtx{
+		            Required: false,
+		            MinArgs: 1,
+		            MaxArgs: cli.InfiniteArgs, 
+		        },
+	        },
             cli.Flag{
                 Name: "resD",
                 LongName: "reservation-day",
@@ -686,16 +680,16 @@ func (c *ResolvedCLI) initParseCtx() {
                     MaxArgs: 1,
                 },
             },
-	    cli.Flag{
-		Name: "t",
-		LongName: "table",
-		Description: "This flag is optional. Used to set the type of table in order of preference",
-		ValidationCtx: cli.FlagValidationCtx{
-		    Required: false,
-		    MinArgs: 1,
-		    MaxArgs: cli.InfiniteArgs, 
-		},
-	    },
+	        cli.Flag{
+		        Name: "t",
+		        LongName: "table",
+		        Description: "This flag is optional. Used to set the type of table in order of preference",
+		        ValidationCtx: cli.FlagValidationCtx{
+		            Required: false,
+		            MinArgs: 1,
+		            MaxArgs: cli.InfiniteArgs, 
+		        },
+	        },
             cli.Flag{
                 Name: "resD",
                 LongName: "reservation-day",
@@ -769,6 +763,26 @@ func (c *ResolvedCLI) initParseCtx() {
                 Name: "p",
                 LongName: "password",
                 Description: "This flag is required. Provides login password",
+                ValidationCtx: cli.FlagValidationCtx{
+                    Required: true,
+                    MaxArgs: 1,
+                    MinArgs: 1,
+                },
+            },
+        },
+        Handler: c.handleLogin,
+    }
+
+    // 'logout' command
+    logoutCommand := cli.Command{
+        Name: "logout",
+        Description: "Clear default login credentials",
+        Flags: []cli.Flag{},
+        Handler: c.handleLogout,
+    }
+
+    // 'cancel' command
+    cancelCommand := cli.Command{
         Name: "cancel",
         Description: "Cancel operations given ids",
         Flags: []cli.Flag{

--- a/runnable/cli/runnable.go
+++ b/runnable/cli/runnable.go
@@ -593,7 +593,7 @@ func (c *ResolvedCLI) initParseCtx() {
 	        cli.Flag{
 		        Name: "t",
 		        LongName: "table",
-		        Description: "This flag is optional. Used to set the type of table in order of preference",
+		        Description: "This flag is optional. Used to set the type of table in order of preference. The available types are dining, patio, bar, lounge, indoor, and outdoor",
 		        ValidationCtx: cli.FlagValidationCtx{
 		            Required: false,
 		            MinArgs: 1,
@@ -683,7 +683,7 @@ func (c *ResolvedCLI) initParseCtx() {
 	        cli.Flag{
 		        Name: "t",
 		        LongName: "table",
-		        Description: "This flag is optional. Used to set the type of table in order of preference",
+		        Description: "This flag is optional. Used to set the type of table in order of preference. The available types are dining, patio, bar, lounge, indoor, and outdoor",
 		        ValidationCtx: cli.FlagValidationCtx{
 		            Required: false,
 		            MinArgs: 1,

--- a/runnable/cli/runnable.go
+++ b/runnable/cli/runnable.go
@@ -281,6 +281,9 @@ func (c *ResolvedCLI) parseRais(in map[string][]string) (*app.ReserveAtIntervalP
     }
     if in["p"] != nil {
         req.Login.Password = in["p"][0]
+    } 
+    if in["t"] != nil {
+	
     }
     id, err := strconv.ParseInt(in["v"][0], 10, 64)
     if err != nil {
@@ -542,6 +545,16 @@ func (c *ResolvedCLI) initParseCtx() {
                     MaxArgs: 1,
                 },
             },
+	    cli.Flag{
+		Name: "t",
+		LongName: "table",
+		Description: "This flag is optional. Used to set the type of table in order of preference",
+		ValidationCtx: cli.FlagValidationCtx{
+		    Required: false,
+		    MinArgs: 1,
+		    MaxArgs: cli.InfiniteArgs, 
+		},
+	    },
             cli.Flag{
                 Name: "resD",
                 LongName: "reservation-day",
@@ -622,6 +635,16 @@ func (c *ResolvedCLI) initParseCtx() {
                     MaxArgs: 1,
                 },
             },
+	    cli.Flag{
+		Name: "t",
+		LongName: "table",
+		Description: "This flag is optional. Used to set the type of table in order of preference",
+		ValidationCtx: cli.FlagValidationCtx{
+		    Required: false,
+		    MinArgs: 1,
+		    MaxArgs: cli.InfiniteArgs, 
+		},
+	    },
             cli.Flag{
                 Name: "resD",
                 LongName: "reservation-day",


### PR DESCRIPTION
Since these changes have been tested by me individually, and not contentions have been raised, I think it's time they get merged into the develop branch. These changes add a new optional flag to `rais` and `rats` that allows someone to specify table types in a preference list. So for example, -t indoor outdoor dining will try to reserve each time on the -resT list, first only looking for slots with indoor seating, then another iteration for slots with outdoor seating, and finally slots with dining room seating.